### PR TITLE
Customizable window options

### DIFF
--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -70,7 +70,7 @@ function neoterm.open(opts)
       border = "single",
     }
 
-    local wo = config.winopts
+    local wo = opts.winopts or config.winopts
     local mode = wo and "custom" or opts.mode or config.mode
     if wo then
       wo = type(wo) == "function" and wo() or wo

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -90,7 +90,7 @@ function neoterm.open(opts)
     state.last_mode = mode
     state.winh = vim.api.nvim_open_win(state.bufh, true, winopts)
 
-    local wh = config.winhighlight
+    local wh = opts.winhighlight or config.winhighlight
     if wh then
       wh = type(wh) == "function" and wh() or wh
       vim.api.nvim_win_set_option(state.winh, "winhighlight", wh)

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -187,7 +187,7 @@ function neoterm.run(command, opts)
   }
 
   if win_is_open() == false or state.chan == nil then
-    neoterm.open()
+    neoterm.open(opts)
   end
 
   if state.last_command ~= nil then

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -88,8 +88,6 @@ function neoterm.open(opts)
     end
 
     state.last_mode = mode
-    print(state.last_mode)
-
     state.winh = vim.api.nvim_open_win(state.bufh, true, winopts)
 
     local wh = config.winhighlight


### PR DESCRIPTION
Somewhat addressing issue #3 

Window options, as well as Window highlights, can now be customized.
Run now passes it's opts to Open. 

This allows a workaround for the window opening off screen in certain Neovide builds by setting  winopts.col to around the difference between the UI width and winopts.width.

I personally use 
```lua 
winopts.col = vim.o.co - width - 5
```

_The math floor was a remnant from division. :D_