### PR TITLE
!Add position option with 6 configurable positions (replaces mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ The following functions are available on the neoterm module. They map directly t
 ```lua
 -- Setup global config
 require('neoterm').setup({
-	clear_on_run = true, -- run clear command before user specified commands
-	mode = 'vertical',   -- vertical/horizontal/fullscreen
-	noinsert = false     -- disable entering insert mode when opening the neoterm window
+  clear_on_run = true, -- Run clear command before user specified commands
+  position = 'right',  -- Position of the terminal window: fullscreen (0), top (1), right (2), bottom (3), left (4), center (5) (string or integer value)
+  noinsert = false,    -- Disable entering insert mode when opening the neoterm window
+  width = 0.5,         -- Width of the terminal window (percentage, ratio, or range between 0-1)
+  height = 1,          -- Height of the terminal window (percentage, ratio, or range between 0-1)
 })
 
 
@@ -38,7 +40,7 @@ local neoterm = require('neoterm')
 
 neoterm.open()
 -- Override global config on a specific open call
-neoterm.open({ mode = 'horizontal', noinsert = true})
+neoterm.open({ position = 'bottom', noinsert = true, width = 0.7, height = 0.3 })
 neoterm.close()
 neoterm.toggle()
 neoterm.run('ls')
@@ -62,22 +64,60 @@ tnoremap <leader>tx <cmd>NeotermExit<CR>
 
 # Screenshots
 
-## Vertical (default)
+## Right (default)
 ```lua
 require('neoterm').open()
 -- or
-require('neoterm').open({mode ='vertical'})
+require('neoterm').open({ position = 'right' })
+-- or
+require('neoterm').open({ position = 2 })
 ```
-![image](https://user-images.githubusercontent.com/8384983/126306361-353a61ad-dfa3-4a16-b9f3-0cc8a6a258f6.png)
+![position-right](https://user-images.githubusercontent.com/8384983/126306361-353a61ad-dfa3-4a16-b9f3-0cc8a6a258f6.png)
 
-## Horizontal
+## Top
 ```lua
-require('neoterm').open({mode ='horizontal'})
+require('neoterm').open({ position = 'top', height = 0.8 })
 ```
-![image](https://user-images.githubusercontent.com/8384983/126306318-bd1c43e4-154a-4a52-9eff-d77dc683c38c.png)
+![position-top](https://user-images.githubusercontent.com/8384983/126306318-bd1c43e4-154a-4a52-9eff-d77dc683c38c.png)
+
+## Bottom
+```lua
+require('neoterm').open({ position = 'bottom' })
+--or
+require('neoterm').open({ position = 3 })
+```
+![position-bottom](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
+
+## Left
+```lua
+require('neoterm').open({ position = 'left', width = 0.7 })
+```
+![position-left](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
+
+## Center
+```lua
+require('neoterm').open({ position = 'left', width = 0.6, height = 0.6 })
+```
+![position-center](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
 
 ## Fullscreen
 ```lua
-require('neoterm').open({mode ='fullscreen'})
+require('neoterm').open({ position = 'fullscreen' })
+-- or
+require('neoterm').open({ position = 0 })
 ```
-![image](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
+![position-fullscreen](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
+
+
+## Deprecation Notice
+
+> [!WARNING]
+> The mode option is deprecated. Please use the new position option instead.
+
+#### Migration Guide
+
+- vertical → right
+
+- horizontal → bottom
+
+- fullscreen → fullscreen

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ require('neoterm').open({ position = 2 })
 
 ## Top
 ```lua
-require('neoterm').open({ position = 'top', height = 0.8 })
+require('neoterm').open({ position = 'top', height = 0.6 })
 ```
-![position-top](https://github.com/user-attachments/assets/a936eda0-ca5f-4c0c-b737-7b6dc4f1bee1)
+![position-top](https://github.com/user-attachments/assets/3aba21d5-b0b2-4250-a415-cc478916c90a)
 
 ## Bottom
 ```lua
@@ -91,13 +91,13 @@ require('neoterm').open({ position = 3 })
 ```lua
 require('neoterm').open({ position = 'left', width = 0.7 })
 ```
-![position-left](https://github.com/user-attachments/assets/8c6b625a-af7b-4bd1-9a7f-853db024b8b1)
+![position-left](https://github.com/user-attachments/assets/812a7d5b-31ed-4061-9bc8-93236b0763f4)
 
 ## Center
 ```lua
 require('neoterm').open({ position = 'left', width = 0.6, height = 0.6 })
 ```
-![position-center](https://github.com/user-attachments/assets/2c2411e0-04e2-41ad-829b-aeddc3f22b9f)
+![position-center](https://github.com/user-attachments/assets/4cbbf668-c7d4-43ee-a9a6-2e5a6ba3b9fb)
 
 ## Fullscreen
 ```lua

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ require('neoterm').setup({
   height = 1,          -- Height of the terminal window (percentage, ratio, or range between 0-1)
 })
 
-
 local neoterm = require('neoterm')
 
 neoterm.open()
@@ -72,13 +71,13 @@ require('neoterm').open({ position = 'right' })
 -- or
 require('neoterm').open({ position = 2 })
 ```
-![position-right](https://user-images.githubusercontent.com/8384983/126306361-353a61ad-dfa3-4a16-b9f3-0cc8a6a258f6.png)
+![position-right](https://github.com/user-attachments/assets/f60ded98-8be4-4dd6-a77b-757ece4f5d84)
 
 ## Top
 ```lua
 require('neoterm').open({ position = 'top', height = 0.8 })
 ```
-![position-top](https://user-images.githubusercontent.com/8384983/126306318-bd1c43e4-154a-4a52-9eff-d77dc683c38c.png)
+![position-top](https://github.com/user-attachments/assets/a936eda0-ca5f-4c0c-b737-7b6dc4f1bee1)
 
 ## Bottom
 ```lua
@@ -86,19 +85,19 @@ require('neoterm').open({ position = 'bottom' })
 --or
 require('neoterm').open({ position = 3 })
 ```
-![position-bottom](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
+![position-bottom](https://github.com/user-attachments/assets/4c3f557c-44ca-4894-a75d-ef45a3943942)
 
 ## Left
 ```lua
 require('neoterm').open({ position = 'left', width = 0.7 })
 ```
-![position-left](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
+![position-left](https://github.com/user-attachments/assets/8c6b625a-af7b-4bd1-9a7f-853db024b8b1)
 
 ## Center
 ```lua
 require('neoterm').open({ position = 'left', width = 0.6, height = 0.6 })
 ```
-![position-center](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
+![position-center](https://github.com/user-attachments/assets/2c2411e0-04e2-41ad-829b-aeddc3f22b9f)
 
 ## Fullscreen
 ```lua
@@ -106,18 +105,18 @@ require('neoterm').open({ position = 'fullscreen' })
 -- or
 require('neoterm').open({ position = 0 })
 ```
-![position-fullscreen](https://user-images.githubusercontent.com/8384983/126306383-192ea5a2-7d5b-4267-a3b7-9cee0751c44a.png)
+![position-fullscreen](https://github.com/user-attachments/assets/9423e593-2c86-48aa-8cba-49024c38e3be)
 
 
 ## Deprecation Notice
 
 > [!WARNING]
-> The mode option is deprecated. Please use the new position option instead.
+> The `mode` option is deprecated. Please use the new `position` option instead.
 
 #### Migration Guide
 
-- vertical → right
+- `mode = vertical` → `position = right`
 
-- horizontal → bottom
+- `mode = horizontal` → `position = bottom`
 
-- fullscreen → fullscreen
+- `mode = fullscreen` → `position = fullscreen`

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -1,9 +1,10 @@
-*neoterm.txt*                                         Last change: 2022 June 14
+*neoterm.txt*                                         Last change: 2024 September 25
 ==============================================================================
 CONTENTS                                                              *neoterm*
 
   1. Commands ....... |neoterm-commands|
   2. Events ......... |neoterm-events|
+  3. Configuration .. |neoterm-configuration|
 
 ==============================================================================
 Section 1: Commands                                          *neoterm-commands*
@@ -43,14 +44,58 @@ NeotermWinOpen
 
                                                               *NeotermWinClose*
 NeotermWinClose
-    Fired when the neoterm window is opened.
+    Fired when the neoterm window is closed.
 
                                                              *NeotermTermEnter*
 NeotermTermEnter
-    Fired when the entering Terminal Mode in the Neoterm buffer.
+    Fired when entering Terminal Mode in the Neoterm buffer.
 
                                                              *NeotermTermLeave*
 NeotermTermLeave
-    Fired when the leaving Terminal Mode in the Neoterm buffer.
+    Fired when leaving Terminal Mode in the Neoterm buffer.
 
+==============================================================================
+Section 3: Configuration                                  *neoterm-configuration*
+
+The neoterm plugin can be configured using the `setup` function. The following
+options are available:
+
+                                                                 *neoterm-setup*
+:lua require('neoterm').setup({options})
+
+    Configure the neoterm plugin with the given options.
+
+    Options:
+
+    clear_on_run (boolean)
+        Run the clear command before user specified commands. Default: true.
+
+    position (string)
+        Position of the terminal window. Possible values:
+        - 'fullscreen'
+        - 'top'
+        - 'right' (default)
+        - 'bottom'
+        - 'left'
+        - 'center'
+
+    noinsert (boolean)
+        Disable entering insert mode when opening the neoterm window. Default: false.
+
+    width (number or string)
+        Width of the terminal window. Can be a number between 0 and 1 or a percentage string (e.g., '50%'). Default: 0.5.
+
+    height (number or string)
+        Height of the terminal window. Can be a number between 0 and 1 or a percentage string (e.g., '50%'). Default: 1.
+
+    Deprecation Notice:
+    The `mode` option is deprecated. Please use the `position` option instead.
+    The `mode` option will be removed in future versions.
+
+    Migration Guide:
+    - 'vertical' → 'right'
+    - 'horizontal' → 'bottom'
+    - 'fullscreen' → 'fullscreen'
+
+==============================================================================
 vim:textwidth=78:tabstop=4:expandtab:shiftwidth=4:filetype=help:

--- a/doc/tags
+++ b/doc/tags
@@ -9,5 +9,6 @@ NeotermWinClose	neoterm.txt	/*NeotermWinClose*
 NeotermWinOpen	neoterm.txt	/*NeotermWinOpen*
 neoterm	neoterm.txt	/*neoterm*
 neoterm-commands	neoterm.txt	/*neoterm-commands*
+neoterm-configuration	neoterm.txt	/*neoterm-configuration*
 neoterm-events	neoterm.txt	/*neoterm-events*
 neoterm.txt	neoterm.txt	/*neoterm.txt*

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -97,6 +97,24 @@ function neoterm.setup(opts)
   config.height = height
 end
 
+local function normalize_position(position)
+  if type(position) == "string" then
+    local temp_position = {
+      ["fullscreen"] = 0,
+      ["top"] = 1,
+      ["right"] = 2,
+      ["bottom"] = 3,
+      ["left"] = 4,
+      ["center"] = 5,
+    }
+    position = temp_position[position]
+    if position == nil then
+      error("Invalid position value. Position must be one of: fullscreen, top, right, bottom, left, center.")
+    end
+  end
+  return position
+end
+
 -- Opens the terminal window. If it was opened previously, the same terminal buffer will be used
 -- Options:
 --	position - override the global config position
@@ -117,7 +135,7 @@ function neoterm.open(opts)
   if win_is_open() ~= true then
     local ui = vim.api.nvim_list_uis()[1]
 
-    local position = opts.position or config.position
+    local position = normalize_position(opts.position or config.position)
     local width = opts.width or config.width
     local height = opts.height or config.height
 
@@ -135,17 +153,6 @@ function neoterm.open(opts)
       style = "minimal",
       border = "single",
     }
-
-    if type(position) == "string" then
-      position = ({
-        ["fullscreen"] = 0,
-        ["top"] = 1,
-        ["right"] = 2,
-        ["bottom"] = 3,
-        ["left"] = 4,
-        ["center"] = 5,
-      })[position]
-    end
 
     if position == 0 then  -- fullscreen
       winopts.width = ui.width

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -34,7 +34,7 @@ local neoterm = {}
 -- Options:
 --	clear_on_run - send the clear command before running a command with run or rerun
 --	position - set where the terminal window will be displayed
---		* full screen (0)
+--		* fullscreen (0)
 --		* top (1)
 --		* right (2)
 --		* bottom (3)
@@ -115,7 +115,7 @@ function neoterm.open(opts)
 
     if type(position) == "string" then
       position = ({
-        ["full screen"] = 0,
+        ["fullscreen"] = 0,
         ["top"] = 1,
         ["right"] = 2,
         ["bottom"] = 3,
@@ -124,7 +124,7 @@ function neoterm.open(opts)
       })[position]
     end
 
-    if position == 0 then  -- full screen
+    if position == 0 then  -- fullscreen
       winopts.width = ui.width
       winopts.height = ui.height - vim.o.cmdheight - 3
       winopts.row = 0
@@ -155,7 +155,7 @@ function neoterm.open(opts)
       winopts.row = math.floor((ui.height - winopts.height) / 2)
       winopts.col = math.floor((ui.width - winopts.width) / 2)
     else
-      error("Invalid position value. Position must be one of: full screen, top, right, bottom, left, center.")
+      error("Invalid position value. Position must be one of: fullscreen, top, right, bottom, left, center.")
     end
 
     state.last_position = position

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -120,10 +120,12 @@ function neoterm.open(opts)
     local width = opts.width or config.width
     local height = opts.height or config.height
 
-    -- Set default height for top, bottom, and center positions if no height is provided
-    if not opts.height then
-      if position == "top" or position == "bottom" or position == "center" then
+    -- If no height is provided and position is 'top', 'bottom', or 'center', set default height
+    if config.height == 1 then
+      if position == 'top' or position == 'bottom' or position == 'center' then
         height = 0.5
+      else
+        height = config.height
       end
     end
 

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -48,7 +48,8 @@ function neoterm.setup(opts)
 
   -- Handle deprecated mode parameter
   if opts.mode then
-    vim.notify("The 'mode' parameter is deprecated. Please use 'position' instead.", vim.log.levels.WARN)
+    vim.notify("Neoterm Warning!", vim.log.levels.WARN)
+    print("The 'mode' option is deprecated. Please use 'position' instead.")
     local mode_to_position = {
       vertical = "right",
       horizontal = "bottom",

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -120,6 +120,13 @@ function neoterm.open(opts)
     local width = opts.width or config.width
     local height = opts.height or config.height
 
+    -- Set default height for top, bottom, and center positions if no height is provided
+    if not opts.height then
+      if position == "top" or position == "bottom" or position == "center" then
+        height = 0.5
+      end
+    end
+
     local winopts = {
       relative = "editor",
       style = "minimal",

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -44,6 +44,19 @@ local neoterm = {}
 --	width - set the width of the terminal window (percentage, ratio, or range between 0-1)
 --	height - set the height of the terminal window (percentage, ratio, or range between 0-1)
 function neoterm.setup(opts)
+  opts = opts or {}
+
+  -- Handle deprecated mode parameter
+  if opts.mode then
+    vim.notify("The 'mode' parameter is deprecated. Please use 'position' instead.", vim.log.levels.WARN)
+    local mode_to_position = {
+      vertical = "right",
+      horizontal = "bottom",
+      fullscreen = "fullscreen",
+    }
+    opts.position = mode_to_position[opts.mode] or opts.position
+  end
+
   config.position = opts.position or config.position
   config.noinsert = opts.noinsert or config.noinsert
   config.width = opts.width or config.width

--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -3,13 +3,15 @@ local state = {
   bufh = nil,
   chan = nil,
   last_command = nil,
-  last_mode = nil,
+  last_position = nil,
 }
 
 local config = {
   clear_on_run = true,
-  mode = "vertical",
+  position = "right",  -- Default position is right
   noinsert = false,
+  width = 0.5,  -- Default width is 50%
+  height = 1,  -- Default height is 100%
 }
 
 -- Returns a bool to show if the neoterm window exists
@@ -30,21 +32,63 @@ local neoterm = {}
 
 -- Sets global configuration
 -- Options:
---	clear_on_run - send the clear comand before running a command with run or rerun
---	mode - set how the terminal window will be displayed
---		* vertical
---		* horizonal
---		* fullscreen
+--	clear_on_run - send the clear command before running a command with run or rerun
+--	position - set where the terminal window will be displayed
+--		* full screen (0)
+--		* top (1)
+--		* right (2)
+--		* bottom (3)
+--		* left (4)
+--		* center (5)
 --	noinsert - don't enter insert mode when switching to the neoterm window
+--	width - set the width of the terminal window (percentage, ratio, or range between 0-1)
+--	height - set the height of the terminal window (percentage, ratio, or range between 0-1)
 function neoterm.setup(opts)
-  config.mode = opts.mode or config.mode
+  config.position = opts.position or config.position
   config.noinsert = opts.noinsert or config.noinsert
+  config.width = opts.width or config.width
+  config.height = opts.height or config.height
+
+  -- Validate and normalize width
+  local width = config.width
+  if type(width) == "number" then
+    if width < 0 or width > 1 then
+      error("Invalid width value. Width must be between 0 and 1.")
+    end
+  elseif type(width) == "string" then
+    if not width:match("^%d+%%$") then
+      error("Invalid width value. Width must be a percentage string (e.g., '50%').")
+    end
+    width = tonumber(width:sub(1, -2)) / 100
+  else
+    error("Invalid width value. Width must be a number between 0 and 1 or a percentage string.")
+  end
+
+  -- Validate and normalize height
+  local height = config.height
+  if type(height) == "number" then
+    if height < 0 or height > 1 then
+      error("Invalid height value. Height must be between 0 and 1.")
+    end
+  elseif type(height) == "string" then
+    if not height:match("^%d+%%$") then
+      error("Invalid height value. Height must be a percentage string (e.g., '50%').")
+    end
+    height = tonumber(height:sub(1, -2)) / 100
+  else
+    error("Invalid height value. Height must be a number between 0 and 1 or a percentage string.")
+  end
+
+  config.width = width
+  config.height = height
 end
 
 -- Opens the terminal window. If it was opened previously, the same terminal buffer will be used
 -- Options:
---	mode - override the global config mode
+--	position - override the global config position
 --	noinsert - don't enter insert mode after switching to the neoterm window
+--	width - override the global config width
+--	height - override the global config height
 function neoterm.open(opts)
   opts = opts or {}
 
@@ -59,28 +103,62 @@ function neoterm.open(opts)
   if win_is_open() ~= true then
     local ui = vim.api.nvim_list_uis()[1]
 
-    local mode = opts.mode or config.mode
+    local position = opts.position or config.position
+    local width = opts.width or config.width
+    local height = opts.height or config.height
 
     local winopts = {
       relative = "editor",
-      width = math.floor(ui.width / 2),
-      height = ui.height - vim.o.cmdheight - 3,
-      row = 0,
-      col = ui.width,
       style = "minimal",
       border = "single",
     }
-    if mode == "horizontal" then
-      winopts.width = ui.width
-      winopts.height = math.floor((ui.height - vim.o.cmdheight - 2) / 3)
-      winopts.row = (2 * winopts.height)
-      winopts.col = 1
-    elseif mode == "fullscreen" then
-      winopts.width = ui.width
-      winopts.col = 1
+
+    if type(position) == "string" then
+      position = ({
+        ["full screen"] = 0,
+        ["top"] = 1,
+        ["right"] = 2,
+        ["bottom"] = 3,
+        ["left"] = 4,
+        ["center"] = 5,
+      })[position]
     end
 
-    state.last_mode = mode
+    if position == 0 then  -- full screen
+      winopts.width = ui.width
+      winopts.height = ui.height - vim.o.cmdheight - 3
+      winopts.row = 0
+      winopts.col = 0
+    elseif position == 1 then  -- top
+      winopts.width = ui.width
+      winopts.height = math.floor(ui.height * height) - vim.o.cmdheight - 3
+      winopts.row = 0
+      winopts.col = 0
+    elseif position == 2 then  -- right
+      winopts.width = math.floor(ui.width * width)
+      winopts.height = ui.height - vim.o.cmdheight - 3
+      winopts.row = 0
+      winopts.col = ui.width - winopts.width
+    elseif position == 3 then  -- bottom
+      winopts.width = ui.width
+      winopts.height = math.floor(ui.height * height) - vim.o.cmdheight - 3
+      winopts.row = ui.height - winopts.height - vim.o.cmdheight - 3
+      winopts.col = 0
+    elseif position == 4 then  -- left
+      winopts.width = math.floor(ui.width * width)
+      winopts.height = ui.height - vim.o.cmdheight - 3
+      winopts.row = 0
+      winopts.col = 0
+    elseif position == 5 then  -- center
+      winopts.width = math.floor(ui.width * width)
+      winopts.height = math.floor(ui.height * height) - vim.o.cmdheight - 3
+      winopts.row = math.floor((ui.height - winopts.height) / 2)
+      winopts.col = math.floor((ui.width - winopts.width) / 2)
+    else
+      error("Invalid position value. Position must be one of: full screen, top, right, bottom, left, center.")
+    end
+
+    state.last_position = position
 
     state.winh = vim.api.nvim_open_win(state.bufh, true, winopts)
     fire_event("NeotermWinOpen")
@@ -130,7 +208,7 @@ function neoterm.open(opts)
   vim.api.nvim_create_autocmd("TermClose", {
     buffer = state.bufh,
     callback = function()
-      state.last_mode = nil
+      state.last_position = nil
     end,
     group = group,
   })
@@ -145,7 +223,7 @@ function neoterm.toggle()
   if win_is_open() then
     neoterm.close()
   else
-    neoterm.open({ mode = state.last_mode })
+    neoterm.open({ position = state.last_position })
   end
 end
 
@@ -158,7 +236,7 @@ function neoterm.exit()
   vim.api.nvim_buf_delete(state.bufh, { force = true })
   state.bufh = nil
 
-  state.last_mode = nil
+  state.last_position = nil
 
   fire_event("NeotermExit")
 end


### PR DESCRIPTION
### BREAKING CHANGE: Replaced "mode" option with "position"

This change introduces a new `position` option, replacing the `mode` option.

#### Position Options
| Position | Integer Value |
| --- | --- |
| full screen | 0 |
| top | 1 |
| right | 2 |
| bottom | 3 |
| left | 4 |
| center | 5 |

* **Vertical positions**: `left` and `right` - `width` option applies
* **Horizontal positions**: `top` and `bottom` - `height` option applies
* **Center position**: both `height` and `width` options apply
* **Full screen position**: neither `height` nor `width` options apply

#### Usage

```lua
require("neoterm").setup({
	clear_on_run = true, -- run clear command before user specified commands
	noinsert = false, -- disable entering insert mode when opening the neoterm window
	position = "left", -- or position = 2
	width = 0.7, -- sets the width to 70%
	height = 0.4, -- doesn't apply to "left" position
})
```
