### PR TITLE
Remove nvim_buf_set_name causing Vim:E95 on Lazy reload

### DIFF
--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -203,7 +203,6 @@ function neoterm.open(opts)
     if buf_created then
       vim.cmd([[term]])
       state.chan = vim.b.terminal_job_id
-      vim.api.nvim_buf_set_name(state.bufh, "neoterm")
       vim.api.nvim_buf_set_option(state.bufh, "buflisted", false)
     end
   end


### PR DESCRIPTION
Fixes #12