### PR TITLE
Replace deprecated nvim_buf_set_option

### DIFF
--- a/lua/neoterm.lua
+++ b/lua/neoterm.lua
@@ -203,8 +203,7 @@ function neoterm.open(opts)
     if buf_created then
       vim.cmd([[term]])
       state.chan = vim.b.terminal_job_id
-      vim.api.nvim_buf_set_name(state.bufh, "neoterm")
-      vim.api.nvim_buf_set_option(state.bufh, "buflisted", false)
+      vim.api.nvim_set_option_value("buflisted", false, { buf = state.bufh })
     end
   end
 


### PR DESCRIPTION
Replaced the deprecated `nvim_buf_set_option` with `nvim_set_option_value`

As reported here:
https://neovim.io/doc/user/deprecated.html#nvim_buf_set_option()